### PR TITLE
Make 'admin-page' not indexed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 client-dist
 node_modules
+dist

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { GetAppService } from './shared/get-app-service/get-app.service';
 import { NewsService } from './controllers/news/news.service';
 import { StreetcodeService } from './controllers/streetcode/streetcode.service';
 import { ClientController } from './controllers/client/client.controller';
+import { AdminNoIndexMiddleware } from './shared/admin-noindex-middleware/admin-noindex.middleware';
 
 @Module({
   imports: [
@@ -29,5 +30,6 @@ export class AppModule implements NestModule {
     consumer
       .apply(FileMiddleware)
       .forRoutes({ path: '*', method: RequestMethod.ALL });
+    consumer.apply(AdminNoIndexMiddleware).forRoutes('admin-panel*');
   }
 }

--- a/src/controllers/news/news.controller.ts
+++ b/src/controllers/news/news.controller.ts
@@ -4,6 +4,7 @@ import News from '../../interfaces/News';
 import { GetAppService } from '../../shared/get-app-service/get-app.service';
 import base64ToUrl from '../../shared/utils/base64ToUrl';
 import NEWS_CONSOLE_MESSAGES from './constants/console.constant';
+import { IPageMetadata } from 'src/shared/get-app-service/constants/defaultMeta.constant';
 
 @Controller()
 export class NewsController {
@@ -40,7 +41,7 @@ export class NewsController {
       image: { base64, mimeType },
     } = theNews;
 
-    const meta = {
+    const meta: IPageMetadata = {
       description: title,
       image: base64ToUrl(base64, mimeType),
     };

--- a/src/controllers/streetcode/streetcode.controller.ts
+++ b/src/controllers/streetcode/streetcode.controller.ts
@@ -9,6 +9,7 @@ import URLS_TO_OMIT from './constants/urlsToOmit.constant';
 import { StreetcodeCache } from '../../interfaces/StreetcodeCache';
 import { Streetcode } from '../../interfaces/Streetcode';
 import STREETCODE_CONSOLE_MESSAGES from './constants/console.constant';
+import { IPageMetadata } from 'src/shared/get-app-service/constants/defaultMeta.constant';
 
 @Controller()
 export class StreetcodeController {
@@ -46,7 +47,7 @@ export class StreetcodeController {
     const id = this.streetcodeCacheUrlsMap.get(url);
     const streetcode = this.streetcodeCacheMap.get(id);
 
-    const meta = {
+    const meta: IPageMetadata = {
       title: streetcode.title,
       image: base64ToUrl(streetcode.image.base64, streetcode.image.mimeType),
     };

--- a/src/shared/admin-noindex-middleware/admin-noindex.middleware.ts
+++ b/src/shared/admin-noindex-middleware/admin-noindex.middleware.ts
@@ -1,0 +1,10 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response } from 'express';
+
+@Injectable()
+export class AdminNoIndexMiddleware implements NestMiddleware {
+  async use(req: Request, res: Response, next: () => void) {
+    res.setHeader('X-Robots-Tag', 'noindex');
+    next();
+  }
+}


### PR DESCRIPTION
## To check this pull request:
- start frontend server;
- download `Robots Exclusion Checker` Chrome Extension;
- go to corresponding pages in admin-panel: `admin-panel/ `...;
- check if following is shown: 
![image](https://github.com/ita-social-projects/StreetCode_FrontendServer/assets/113620149/65df49b6-4f52-4aeb-8534-b059006c15ba)

![image](https://github.com/ita-social-projects/StreetCode_FrontendServer/assets/113620149/e7706b56-36db-40a2-9ba3-7425d00eb2b2)

